### PR TITLE
typing.Self not availabe in Python 3.10

### DIFF
--- a/src/cortical_tools/mesh_vertex.py
+++ b/src/cortical_tools/mesh_vertex.py
@@ -5,7 +5,8 @@ import os
 import warnings
 from copy import copy
 from itertools import combinations
-from typing import TYPE_CHECKING, Optional, Self
+from typing import TYPE_CHECKING, Optional
+from typing_extensions import Self
 
 import psutil
 


### PR DESCRIPTION
importing Self from  typing_extensions instead to make it compatible with Python 3.10
Tested on python 3.10.13.